### PR TITLE
changed curl args to deal with SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ SHELL := bash
 # load into local Maven repository
 
 build/robot.jar: | build
-	curl -L -o $@ https://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot.jar
+	curl -k -L -o $@ https://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot.jar
 
 local_maven_repo: build/robot.jar
 	mkdir -p $@


### PR DESCRIPTION
was getting this:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
make: *** [build/robot.jar] Error 60
```
